### PR TITLE
Do not merge yet! Adding news_type to news articles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ docroot/sites/default/settings.local.php
 .vscode/
 *.code-workspace
 
+# Ignore xdebug log file genearted by lando
+xdebug.log
+
 # Ignore .env files as they are personal
 /.env
 

--- a/.vscode/php.ini
+++ b/.vscode/php.ini
@@ -11,6 +11,6 @@ xdebug.client_port = 9003
 xdebug.start_with_request = yes
 xdebug.discover_client_host = true
 xdebug.remote_connect_back = 1
-xdebug.log = /tmp/xdebug.log
+xdebug.log = /app/xdebug.log
 xdebug.idekey = vsc
 html_errors = 1

--- a/config/default/core.entity_form_display.node.news.default.yml
+++ b/config/default/core.entity_form_display.node.news.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.news.field_display_image
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_main_image
+    - field.field.node.news.field_news_type
     - field.field.node.news.field_notes
     - field.field.node.news.field_paragraphs
     - field.field.node.news.field_project
@@ -181,6 +182,16 @@ content:
     region: content
     settings:
       media_types: {  }
+    third_party_settings: {  }
+  field_news_type:
+    type: entity_reference_autocomplete
+    weight: 29
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_notes:
     type: text_textarea

--- a/config/default/core.entity_view_display.node.news.card.yml
+++ b/config/default/core.entity_view_display.node.news.card.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.news.field_display_image
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_main_image
+    - field.field.node.news.field_news_type
     - field.field.node.news.field_notes
     - field.field.node.news.field_paragraphs
     - field.field.node.news.field_project
@@ -53,6 +54,7 @@ hidden:
   field_contact: true
   field_display_image: true
   field_image_caption: true
+  field_news_type: true
   field_notes: true
   field_paragraphs: true
   field_project: true

--- a/config/default/core.entity_view_display.node.news.default.yml
+++ b/config/default/core.entity_view_display.node.news.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.news.field_display_image
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_main_image
+    - field.field.node.news.field_news_type
     - field.field.node.news.field_notes
     - field.field.node.news.field_paragraphs
     - field.field.node.news.field_project
@@ -80,6 +81,14 @@ content:
       link: true
     third_party_settings: {  }
     weight: 102
+    region: content
+  field_news_type:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 117
     region: content
   field_notes:
     type: text_default

--- a/config/default/core.entity_view_display.node.news.full.yml
+++ b/config/default/core.entity_view_display.node.news.full.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.news.field_display_image
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_main_image
+    - field.field.node.news.field_news_type
     - field.field.node.news.field_notes
     - field.field.node.news.field_paragraphs
     - field.field.node.news.field_project
@@ -122,6 +123,7 @@ content:
     region: content
 hidden:
   field_admin: true
+  field_news_type: true
   field_tagline: true
   field_video: true
   langcode: true

--- a/config/default/core.entity_view_display.node.news.teaser.yml
+++ b/config/default/core.entity_view_display.node.news.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.news.field_display_image
     - field.field.node.news.field_image_caption
     - field.field.node.news.field_main_image
+    - field.field.node.news.field_news_type
     - field.field.node.news.field_notes
     - field.field.node.news.field_paragraphs
     - field.field.node.news.field_project
@@ -52,6 +53,7 @@ hidden:
   field_display_image: true
   field_image_caption: true
   field_main_image: true
+  field_news_type: true
   field_notes: true
   field_paragraphs: true
   field_project: true

--- a/config/default/field.field.node.news.field_news_type.yml
+++ b/config/default/field.field.node.news.field_news_type.yml
@@ -1,0 +1,29 @@
+uuid: cc8342d5-fe5c-4d85-b6ed-bdbfd15ffc88
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_news_type
+    - node.type.news
+    - taxonomy.vocabulary.news_type
+id: node.news.field_news_type
+field_name: field_news_type
+entity_type: node
+bundle: news
+label: 'News type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      news_type: news_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/default/field.storage.node.field_news_type.yml
+++ b/config/default/field.storage.node.field_news_type.yml
@@ -1,0 +1,20 @@
+uuid: 04e0abd9-ba37-46ff-805b-74225e42c4f5
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_news_type
+field_name: field_news_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/language.content_settings.taxonomy_term.news_type.yml
+++ b/config/default/language.content_settings.taxonomy_term.news_type.yml
@@ -1,0 +1,11 @@
+uuid: f7dae1d6-d51f-4b6f-88b3-77d85fc0b4d6
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.news_type
+id: taxonomy_term.news_type
+target_entity_type_id: taxonomy_term
+target_bundle: news_type
+default_langcode: site_default
+language_alterable: false

--- a/config/default/migrate_plus.migration.iied_d7_news_media.yml
+++ b/config/default/migrate_plus.migration.iied_d7_news_media.yml
@@ -160,6 +160,17 @@ process:
   path/pathauto:
     plugin: default_value
     default_value: false
+  field_news_type:
+    -
+      plugin: default_value
+      default_value: News
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      bundle: news_type
+      bundle_key: vid
+      value_key: name
+      ignore_case: true
 destination:
   plugin: 'entity_complete:node'
   translations: true

--- a/config/default/migrate_plus.migration.iied_d7_news_press.yml
+++ b/config/default/migrate_plus.migration.iied_d7_news_press.yml
@@ -94,6 +94,17 @@ process:
   path/pathauto:
     plugin: default_value
     default_value: false
+  field_news_type:
+    -
+      plugin: default_value
+      default_value: 'Press release'
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      bundle: news_type
+      bundle_key: vid
+      value_key: name
+      ignore_case: true
 destination:
   plugin: 'entity_complete:node'
   translations: true

--- a/config/default/rabbit_hole.behavior_settings.taxonomy_vocabulary_news_type.yml
+++ b/config/default/rabbit_hole.behavior_settings.taxonomy_vocabulary_news_type.yml
@@ -1,0 +1,14 @@
+uuid: 8ccb87cf-90a6-40cf-9f9a-7f9350d950f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.news_type
+id: taxonomy_vocabulary_news_type
+entity_type_id: taxonomy_vocabulary
+entity_id: news_type
+action: page_not_found
+allow_override: 1
+redirect: ''
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/config/default/taxonomy.vocabulary.news_type.yml
+++ b/config/default/taxonomy.vocabulary.news_type.yml
@@ -1,0 +1,8 @@
+uuid: 8749dbf7-0f55-4c60-96a7-505318c1d88e
+langcode: en
+status: true
+dependencies: {  }
+name: 'News type'
+vid: news_type
+description: 'Types of news article'
+weight: 0

--- a/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_media.yml
+++ b/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_media.yml
@@ -160,6 +160,17 @@ process:
   path/pathauto:
     plugin: default_value
     default_value: false
+  field_news_type:
+    -
+      plugin: default_value
+      default_value: "News"
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      bundle: news_type
+      bundle_key: vid
+      value_key: name
+      ignore_case: true
 destination:
   plugin: 'entity_complete:node'
   translations: true

--- a/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_press.yml
+++ b/docroot/modules/custom/iied_migrate_d7/config/install/migrate_plus.migration.iied_d7_news_press.yml
@@ -93,6 +93,17 @@ process:
   path/pathauto:
     plugin: default_value
     default_value: false
+  field_news_type:
+    -
+      plugin: default_value
+      default_value: "Press release"
+    -
+      plugin: entity_generate
+      entity_type: taxonomy_term
+      bundle: news_type
+      bundle_key: vid
+      value_key: name
+      ignore_case: true
 destination:
   plugin: 'entity_complete:node'
   translations: true


### PR DESCRIPTION
Hey @cbrody 

As i've just created another pull request for the image styles work, which has yet to be merged (https://github.com/IIED-org/pubs/pull/201) I'm creating this one againset the  [feature/173-replace-image-styles](https://github.com/IIED-org/pubs/tree/feature/173-replace-image-styles) branch so we can see the new changes.

Once that one is merged, we can recreate this one against dev-master.

This addresses https://github.com/IIED-org/pubs/issues/133 

Adds a new vocabulary for 'News type'
Adds a new field_news_type to the news content type.
Adds default values in the migration for: 

 - news_media => "News"
 - news_press => "Press release"
